### PR TITLE
Fix nested configuration type to allow further nesting

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type Configuration = {
 };
 
 export type NestedConfiguration = {
-	[key: string]: ConfigurationItem<any>;
+	[key: string]: ConfigurationItem<any> | NestedConfiguration;
 };
 
 export interface ParsedConfig {


### PR DESCRIPTION
The nested configuration type `NestedConfiguration` was updated to allow further nesting by allowing `ConfigurationItem<any>` or `NestedConfiguration` as values. This change provides more flexibility and usability for defining complex configurations.