### PR TITLE
Refactor EnvironmentLoader to remove .env file loading responsibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install typed-environment-loader
 ## Usage
 
 ```typescript
+import * as dotenv from 'dotenv';
 import { Configuration, EnvironmentLoader, ParsedConfig } from 'typed-environment-loader';
 
 const config: Configuration = {
@@ -59,7 +60,12 @@ interface Config extends ParsedConfig {
  };
  matrix: Array<Array<number>>;
 }
-
+const loadedEnv = dotenv.config({});
+if (loadedEnv.error) {
+    throw new Error(
+    `Error loading environment variables from.env file it must be located in the root of the project.`
+    );
+}
 const loader = new EnvironmentLoader<Config>(config);
 const configObject = loader.loadFromFile().load();
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -41,8 +41,20 @@ interface Config extends ParsedConfig {
 	matrix: Array<Array<number>>;
 }
 
+process.env = {
+	...process.env,
+	PORT: '3000',
+	NODE_ENV: 'development',
+	POSTGRES_HOST: 'localhost',
+	POSTGRES_PASSWORD: '<PASSWORD>',
+	POSTGRES_PORT: '5432',
+	CORS_ENABLED: 'true',
+	CORS_ORIGINS: '["*"]',
+	MATRIX: '[["1", "2"], ["3", "4"]]'
+};
+
 const loader = new EnvironmentLoader<Config>(config);
-const configObject = loader.loadFromFile().load();
+const configObject = loader.load();
 
 // eslint-disable-next-line no-console
 console.log(configObject);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
 			"name": "typed-environment-loader",
 			"version": "0.2.1",
 			"license": "MIT",
-			"dependencies": {
-				"dotenv": "^16.4.5",
-				"typed-environment-loader": "file:"
-			},
 			"devDependencies": {
 				"@types/node": "^20.12.8",
 				"@typescript-eslint/eslint-plugin": "^7.8.0",
@@ -791,17 +787,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2094,10 +2079,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/typed-environment-loader": {
-			"resolved": "",
-			"link": true
 		},
 		"node_modules/typescript": {
 			"version": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,5 @@
 		"prettier": "^3.2.5",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.4.5"
-	},
-	"dependencies": {
-		"dotenv": "^16.4.5"
 	}
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,3 @@
-import * as dotenv from 'dotenv';
 import { Parsers, parsers } from './parsers';
 import { Configuration, ConfigurationItem, ParsedConfig } from './types';
 
@@ -8,16 +7,6 @@ export class EnvironmentLoader<ResultType extends ParsedConfig> {
 
 	constructor(config: Configuration) {
 		this.config = config;
-	}
-
-	loadFromFile() {
-		const loadedEnv = dotenv.config({});
-		if (loadedEnv.error) {
-			throw new Error(
-				`Error loading environment variables from.env file it must be located in the root of the project.`
-			);
-		}
-		return this;
 	}
 
 	private isConfigItem(value: Configuration | ConfigurationItem<any>): value is ConfigurationItem<any> {


### PR DESCRIPTION
Refactor EnvironmentLoader to remove responsibility for loading environment variables from a .env file. Users are now responsible for loading environment variables externally before using the EnvironmentLoader class. This change increases flexibility and simplifies the responsibilities of the EnvironmentLoader class.